### PR TITLE
add: GH Actions workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,22 @@
+on: [push]
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: build the rules
+        run: |
+          docker run -v $(pwd):/documents asciidoctor/docker-asciidoctor .ci/adoc-to-tex.sh rules
+          docker run -v $(pwd):/documents mrshu/texlive-dblatex .ci/tex-to-pdf.sh rules
+          mkdir -p dist/${GITHUB_REF#refs/heads/}/
+          rm tmp_*
+          cp -R ./media *.html *.pdf dist/${GITHUB_REF#refs/heads/}/
+
+      - name: publish the rules
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN  }}
+          publish_dir: ./dist
+          keep_files: True


### PR DESCRIPTION
* Add the GitHub Actions workflow that will ensure the rules get generated on each merge into appropriate branches.

### Please describe your change in one or two sentences

Result of 2023 rule generation process - sadly not used for 2023 season

### Please explain why do you think this change should be in the rules

I'd like to use the 2023 draft as the basis for the 2024 Entry rules so I'd like it to go into master.