### PR TITLE
fix: update remaining 2025 year references to 2026

### DIFF
--- a/preamble.tex
+++ b/preamble.tex
@@ -94,7 +94,7 @@
   \fancyfoot[R]{Page \textbf{\thepage} of \textbf{\pageref{LastPage}}}
 }
 
-\title{\Large RoboCupJunior Soccer Entry Rules 2025\vspace{2ex} \\ \large 1:1 Standard Kit League \& 1:1 Lightweight League\vspace{-10ex}}
+\title{\Large RoboCupJunior Soccer Entry Rules 2026\vspace{2ex} \\ \large 1:1 Standard Kit League \& 1:1 Lightweight League\vspace{-10ex}}
 \date{\vspace{-2ex}}
 
 \definecolor{color-1}{rgb}{1,1,1}

--- a/preamble.tex
+++ b/preamble.tex
@@ -94,7 +94,7 @@
   \fancyfoot[R]{Page \textbf{\thepage} of \textbf{\pageref{LastPage}}}
 }
 
-\title{\Large RoboCupJunior Soccer Entry Rules 2026\vspace{2ex} \\ \large 1:1 Standard Kit League \& 1:1 Lightweight League\vspace{-10ex}}
+\title{\Large RoboCupJunior Soccer Entry Rules 2026\vspace{2ex} \\ \large 1:1 Standard Kit League \& 1:1 Infrared League\vspace{-10ex}}
 \date{\vspace{-2ex}}
 
 \definecolor{color-1}{rgb}{1,1,1}

--- a/rules.adoc
+++ b/rules.adoc
@@ -647,7 +647,7 @@ sub-league | *1:1* *Standard* *Kit* *League* | *1:1* *Infrared* *League* +
 |height | 22.4 cm ^[2]^ | 22.0 cm ^[2]^ +
 |weight | 1400 g | 1400 g ^[3]^ +
 |ball-capturing zone | 3.0 cm | 3.0 cm +
-|voltage | 12.0 V ^[4]^ ^[5]^ +
+|voltage | 9.0 V ^[4]^ ^[5]^ | 12.0 V ^[4]^ ^[5]^ +
 |===
 
 TIP: [0] Robot must fit smoothly into a cube of this size.

--- a/rules.adoc
+++ b/rules.adoc
@@ -29,7 +29,7 @@ tournaments.
 These are the RoboCupJunior Soccer Entry rules for the *1:1 Infrared League*
 and *1:1 Standard Kit League*
 proposed for suggested use by regional and super-regional tournaments in the 
-2025 season. They are released by the RoboCupJunior League Committee. 
+2026 season. They are released by the RoboCupJunior League Committee. 
 The English version of these rules has priority over any translations.
 
 The aim of this document is to provide entry-level rulesets for RoboCupJunior Soccer


### PR DESCRIPTION

### Please describe your change in one or two sentences

The previous batch of year updates missed two references that still said 2025. This updates them to 2026 for the current season.

- Update season year in rules.adoc preamble text
- Update document title year in preamble.tex

### Please explain why do you think this change should be in the rules

To be consistent.